### PR TITLE
Update decayingTurbulenceFvPatchVectorField.C

### DIFF
--- a/LEMOSinflowGeneratorMod/decayingTurbulenceFvPatchVectorField.C
+++ b/LEMOSinflowGeneratorMod/decayingTurbulenceFvPatchVectorField.C
@@ -332,6 +332,7 @@ Foam::decayingTurbulenceFvPatchVectorField::decayingTurbulenceFvPatchVectorField
     width_(ptf.width_),
     midRadius_(ptf.midRadius_),
     center_(ptf.center_),
+    Radius_(ptf.Radius_),
     n_(ptf.n_)
 {
 }
@@ -359,6 +360,7 @@ Foam::decayingTurbulenceFvPatchVectorField::decayingTurbulenceFvPatchVectorField
     width_(ptf.width_),
     midRadius_(ptf.midRadius_),
     center_(ptf.center_),
+    Radius_(ptf.Radius_),
     n_(ptf.n_)
 {
 }


### PR DESCRIPTION
Add Radius_(ptf.Radius_), to copy constructor.Fixed the exception where Radius_ was given a random value after reconstructPar using a circular tube, because the two-parameter constructor of decayingTurbulenceFvPatchVectorField.C was called in the reconstructFvSurfaceField function where Radius_ was not initialised correctly.